### PR TITLE
(feat)add volume support via CLI

### DIFF
--- a/nut.go
+++ b/nut.go
@@ -39,7 +39,7 @@ func main() {
 	ephemeral := flag.Bool("ephemeral", false, "Destroy the container after creating it")
 	versionFalg := flag.Bool("version", false, "Print version information")
 	name := flag.String("name", "", "Name of the resulting container (defaults to randomly generated UUID)")
-	volume := flag.String("volume", "", "Mount host directory inside container. Format: '[host_directory:]container_directory")
+	volume := flag.String("volume", "", "Mount host directory inside container. Format: '[host_directory:]container_directory[:mount options]")
 
 	flag.Parse()
 

--- a/nut.go
+++ b/nut.go
@@ -22,6 +22,7 @@ Options:
 	-name        Name of the container (defaults to randomly generated UUID)
 	-stop        Stop container at the end
 	-version     Print version information
+	-volume      Mount host directory inside container
 	`
 	return strings.TrimSpace(helpText)
 }
@@ -38,6 +39,7 @@ func main() {
 	ephemeral := flag.Bool("ephemeral", false, "Destroy the container after creating it")
 	versionFalg := flag.Bool("version", false, "Print version information")
 	name := flag.String("name", "", "Name of the resulting container (defaults to randomly generated UUID)")
+	volume := flag.String("volume", "", "Mount host directory inside container. Format: '[host_directory:]container_directory")
 
 	flag.Parse()
 
@@ -62,7 +64,7 @@ func main() {
 	if err := spec.Parse(); err != nil {
 		log.Fatalf("Failed to parse dockerfile. Error: %s\n", err)
 	}
-	if err := spec.Build(); err != nil {
+	if err := spec.Build(*volume); err != nil {
 		log.Fatalf("Failed to build container from dockerfile. Error: %s\n", err)
 	}
 	if *stopAfterBuild {

--- a/specification/container.go
+++ b/specification/container.go
@@ -69,7 +69,7 @@ func SetupBindMounts(container *lxc.Container, volume string) error {
 		} else {
 			hostDir = p
 		}
-		options[1] = "bind,create=dir," + parts[2]
+		options[1] = "bind," + parts[2]
 	default:
 		fmt.Errorf("Invalid volume spec. Parts: %d", len(parts))
 	}

--- a/specification/spec.go
+++ b/specification/spec.go
@@ -119,7 +119,7 @@ func (spec *Spec) Destroy() error {
 	return spec.State.Container.Destroy()
 }
 
-func (spec *Spec) Build() error {
+func (spec *Spec) Build(volume string) error {
 	spec.State = BuilderState{
 		manifest: Manifest{
 			Labels:       make(map[string]string),
@@ -137,7 +137,7 @@ func (spec *Spec) Build() error {
 			}
 			var err error
 			name := ParentName(words[1])
-			spec.State.Container, err = CloneAndStartContainer(name, spec.ID)
+			spec.State.Container, err = CloneAndStartContainer(name, spec.ID, volume)
 			if err != nil {
 				log.Errorf("Failed to clone container. Error: %s\n", err)
 				return err


### PR DESCRIPTION
Allow users to set up a bind mount via -volume flag. In its simplest form it will mount the current working directory from host to the specified directory inside container. It will create the directory if needed.
```
nut -volume foo/bar
```
User can optionally specify the host directory
```
nut -volume /tmp/x:/foo/bar
```
will mount /tmp/x from host to /foo/bar inside container.
```
nut -volume /tmp/x:/foo/bar:rw,uid=1000,gid=100
```
will pass additional bind mount options.