### PR TITLE
(feat) Implement rootfs export as tar.xz

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -1,0 +1,76 @@
+package commands
+
+import (
+	"flag"
+	"github.com/PagerDuty/nut/specification"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
+	"strings"
+)
+
+type BuildCommand struct {
+}
+
+func Build() (cli.Command, error) {
+	command := &BuildCommand{}
+	return command, nil
+}
+
+func (command *BuildCommand) Help() string {
+	helpText := `
+		-specfile    Local path to the specification file (defaults to dockerfle)
+		-ephemeral   Destroy the container after creation
+		-name        Name of the container (defaults to randomly generated UUID)
+		-stop        Stop container at the end
+		-volume      Mount host directory inside container
+	`
+	return strings.TrimSpace(helpText)
+}
+
+func (command *BuildCommand) Synopsis() string {
+	synopsis := "Build container from Dockerfile"
+	return synopsis
+}
+
+func (command *BuildCommand) Run(args []string) int {
+	flagSet := flag.NewFlagSet("build", flag.ExitOnError)
+	file := flagSet.String("specfile", "Dockerfile", "Container build specification file")
+	stopAfterBuild := flagSet.Bool("stop", false, "Stop container after build")
+	ephemeral := flagSet.Bool("ephemeral", false, "Destroy the container after creating it")
+	name := flagSet.String("name", "", "Name of the resulting container (defaults to randomly generated UUID)")
+	volume := flagSet.String("volume", "", "Mount host directory inside container. Format: '[host_directory:]container_directory[:mount options]")
+
+	flagSet.Parse(args)
+	if *name == "" {
+		uuid, err := specification.UUID()
+		if err != nil {
+			log.Errorln(err)
+			return -1
+		}
+		name = &uuid
+	}
+	spec := specification.New(*name, *file)
+	if err := spec.Parse(); err != nil {
+		log.Errorf("Failed to parse dockerfile. Error: %s\n", err)
+		return -1
+	}
+	if err := spec.Build(*volume); err != nil {
+		log.Errorf("Failed to build container from dockerfile. Error: %s\n", err)
+		return -1
+	}
+	if *stopAfterBuild {
+		log.Infof("Stopping container")
+		if err := spec.Stop(); err != nil {
+			log.Errorf("Failed to stop container. Error: %s\n", err)
+			return -1
+		}
+	}
+	if *ephemeral {
+		log.Infof("Ephemeral mode. Destroying the container")
+		if err := spec.Destroy(); err != nil {
+			log.Errorf("Failed to destroy container. Error: %s\n", err)
+			return -1
+		}
+	}
+	return 0
+}

--- a/commands/build.go
+++ b/commands/build.go
@@ -23,6 +23,7 @@ func (command *BuildCommand) Help() string {
 		-name        Name of the container (defaults to randomly generated UUID)
 		-stop        Stop container at the end
 		-volume      Mount host directory inside container
+		-export      Create tarball of container rootfs (assumes -stop)
 	`
 	return strings.TrimSpace(helpText)
 }
@@ -33,11 +34,15 @@ func (command *BuildCommand) Synopsis() string {
 }
 
 func (command *BuildCommand) Run(args []string) int {
+
 	flagSet := flag.NewFlagSet("build", flag.ExitOnError)
+
 	file := flagSet.String("specfile", "Dockerfile", "Container build specification file")
 	stopAfterBuild := flagSet.Bool("stop", false, "Stop container after build")
 	ephemeral := flagSet.Bool("ephemeral", false, "Destroy the container after creating it")
 	name := flagSet.String("name", "", "Name of the resulting container (defaults to randomly generated UUID)")
+	export := flagSet.String("export", "", "File path for the container tarball")
+	exportSudo := flagSet.Bool("export-sudo", false, "Use sudo while invoking tar")
 	volume := flagSet.String("volume", "", "Mount host directory inside container. Format: '[host_directory:]container_directory[:mount options]")
 
 	flagSet.Parse(args)
@@ -49,15 +54,19 @@ func (command *BuildCommand) Run(args []string) int {
 		}
 		name = &uuid
 	}
+
 	spec := specification.New(*name, *file)
+
 	if err := spec.Parse(); err != nil {
 		log.Errorf("Failed to parse dockerfile. Error: %s\n", err)
 		return -1
 	}
+
 	if err := spec.Build(*volume); err != nil {
 		log.Errorf("Failed to build container from dockerfile. Error: %s\n", err)
 		return -1
 	}
+
 	if *stopAfterBuild {
 		log.Infof("Stopping container")
 		if err := spec.Stop(); err != nil {
@@ -65,6 +74,20 @@ func (command *BuildCommand) Run(args []string) int {
 			return -1
 		}
 	}
+
+	if *export != "" {
+		log.Infof("Stopping container")
+		if err := spec.Stop(); err != nil {
+			log.Errorf("Failed to stop container. Error: %s\n", err)
+			return -1
+		}
+		log.Infof("Exporting container")
+		if err := spec.ExportContainer(*export, *exportSudo); err != nil {
+			log.Errorf("Failed to export container. Error: %s\n", err)
+			return -1
+		}
+	}
+
 	if *ephemeral {
 		log.Infof("Ephemeral mode. Destroying the container")
 		if err := spec.Destroy(); err != nil {

--- a/examples/minimal
+++ b/examples/minimal
@@ -1,0 +1,1 @@
+FROM trusty

--- a/nut.go
+++ b/nut.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"flag"
-	"fmt"
-	"github.com/PagerDuty/nut/specification"
+	"github.com/PagerDuty/nut/commands"
+	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
+	"os"
 	"strings"
 )
 
@@ -17,12 +17,7 @@ Usage: nut [options]
 Options:
 
 	-help        Show usage
-	-specfile    Local path to the specification file (defaults to dockerfle)
-	-ephemeral   Destroy the container after creation
-	-name        Name of the container (defaults to randomly generated UUID)
-	-stop        Stop container at the end
 	-version     Print version information
-	-volume      Mount host directory inside container
 	`
 	return strings.TrimSpace(helpText)
 }
@@ -32,51 +27,14 @@ const (
 )
 
 func main() {
-
-	file := flag.String("specfile", "Dockerfile", "Container build specification file")
-	help := flag.Bool("help", false, "Show usage")
-	stopAfterBuild := flag.Bool("stop", false, "Stop container after build")
-	ephemeral := flag.Bool("ephemeral", false, "Destroy the container after creating it")
-	versionFalg := flag.Bool("version", false, "Print version information")
-	name := flag.String("name", "", "Name of the resulting container (defaults to randomly generated UUID)")
-	volume := flag.String("volume", "", "Mount host directory inside container. Format: '[host_directory:]container_directory[:mount options]")
-
-	flag.Parse()
-
-	if *help {
-		fmt.Println(usage())
-		return
+	c := cli.NewCLI("nut", version)
+	c.Args = os.Args[1:]
+	c.Commands = map[string]cli.CommandFactory{
+		"build": commands.Build,
 	}
-
-	if *versionFalg {
-		fmt.Println(version)
-		return
+	exitStatus, err := c.Run()
+	if err != nil {
+		log.Errorln(err)
 	}
-
-	if *name == "" {
-		uuid, err := specification.UUID()
-		if err != nil {
-			log.Fatalf("Failed to create uuid. Error: %s\n", err)
-		}
-		name = &uuid
-	}
-	spec := specification.New(*name, *file)
-	if err := spec.Parse(); err != nil {
-		log.Fatalf("Failed to parse dockerfile. Error: %s\n", err)
-	}
-	if err := spec.Build(*volume); err != nil {
-		log.Fatalf("Failed to build container from dockerfile. Error: %s\n", err)
-	}
-	if *stopAfterBuild {
-		log.Infof("Stopping container")
-		if err := spec.Stop(); err != nil {
-			log.Fatalf("Failed to stop container. Error: %s\n", err)
-		}
-	}
-	if *ephemeral {
-		log.Infof("Ephemeral mode. Destroying the container")
-		if err := spec.Destroy(); err != nil {
-			log.Fatalf("Failed to destroy container. Error: %s\n", err)
-		}
-	}
+	os.Exit(exitStatus)
 }

--- a/specification/spec.go
+++ b/specification/spec.go
@@ -21,6 +21,7 @@ type Manifest struct {
 	Labels       map[string]string
 	Maintainers  []string
 	ExposedPorts []uint64
+	EntryPoint   []string
 }
 
 type BuilderState struct {
@@ -199,9 +200,21 @@ func (spec *Spec) Build(volume string) error {
 		case "STOPSIGNAL":
 			// FIXME
 		case "CMD":
-			// FIXME
+			if len(spec.State.manifest.EntryPoint) == 0 {
+				spec.State.manifest.EntryPoint = words[1:]
+			} else {
+				log.Errorf("Entrypoint/CMD is already defined. Probably multiple declaration")
+				return fmt.Errorf("Entrypoint/CMD is already defined. Probably multiple declaration")
+			}
 		case "ENTRYPOINT":
-			// FIXME
+			if len(spec.State.manifest.EntryPoint) == 0 {
+				spec.State.manifest.EntryPoint = words[1:]
+			} else {
+				log.Errorf("Entrypoint/CMD is already defined. Probably multiple declaration")
+				return fmt.Errorf("Entrypoint/CMD is already defined. Probably multiple declaration")
+			}
+		default:
+			fmt.Errorf("Unknown instruction")
 		}
 	}
 	if err := spec.fetchArtifact(); err != nil {

--- a/specification/spec.go
+++ b/specification/spec.go
@@ -309,3 +309,23 @@ func (spec *Spec) runCommand(command []string) error {
 	}
 	return nil
 }
+
+func (spec *Spec) ExportContainer(file string, sudo bool) error {
+	//command := "sudo tar -Jcf rootfs1.tar.xz -C ~/.local/share/lxc/ruby_2.3/rootfs  . --numeric-owner"
+	rootfs := spec.State.Container.ConfigItem("lxc.rootfs")[0]
+	command := fmt.Sprintf("tar -Jcf %s -C %s  . --numeric-owner", file, rootfs)
+	if sudo {
+		command = "sudo " + command
+
+	}
+	log.Infof("Invoking: %s", command)
+	parts := strings.Fields(command)
+	cmd := exec.Command(parts[0], parts[1:]...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Error(string(out))
+		log.Error(err)
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
- introduce subcommands (i.e dockerfile will now be built by `nut build` command instead)
- implement tar.xz export of container rootfs