### PR TITLE
(chore) Extract archive, restore and publish as sub command as well

### DIFF
--- a/commands/archive.go
+++ b/commands/archive.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"errors"
+	"flag"
+	"github.com/PagerDuty/nut/specification"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
+	"strings"
+)
+
+type ArchiveCommand struct{}
+
+func Archive() (cli.Command, error) {
+	command := &ArchiveCommand{}
+	return command, nil
+}
+
+func (command *ArchiveCommand) Help() string {
+	helpText := `
+	Usage: nut archive [options] <container> <image>
+	`
+	return strings.TrimSpace(helpText)
+}
+
+func (command *ArchiveCommand) Synopsis() string {
+	return "Create tarball images of existing container"
+}
+
+func (command *ArchiveCommand) Run(args []string) int {
+	flagSet := flag.NewFlagSet("archive", flag.ExitOnError)
+	sudo := flagSet.Bool("sudo", false, "Use sudo while invoking tar")
+	log.Infof("Exporting container")
+
+	if err := flagSet.Parse(args); err != nil {
+		log.Errorln(err)
+		return -1
+	}
+
+	args = flagSet.Args()
+	if len(args) != 2 {
+		log.Errorln(errors.New("Insufficient argument. Please pass container name and image file name"))
+		return -1
+	}
+
+	if err := specification.ExportContainer(args[0], args[1], *sudo); err != nil {
+		log.Errorf("Failed to export container. Error: %s\n", err)
+		return -1
+	}
+	return 0
+}

--- a/commands/archive.go
+++ b/commands/archive.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"errors"
 	"flag"
+	"fmt"
 	"github.com/PagerDuty/nut/specification"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
@@ -19,6 +20,11 @@ func Archive() (cli.Command, error) {
 func (command *ArchiveCommand) Help() string {
 	helpText := `
 	Usage: nut archive [options] <container> <image>
+
+	nut archive is used to build tarball image from an existing
+	container.
+
+	-sudo    Use sudo while invoking tar
 	`
 	return strings.TrimSpace(helpText)
 }
@@ -29,9 +35,8 @@ func (command *ArchiveCommand) Synopsis() string {
 
 func (command *ArchiveCommand) Run(args []string) int {
 	flagSet := flag.NewFlagSet("archive", flag.ExitOnError)
+	flagSet.Usage = func() { fmt.Println(command.Help()) }
 	sudo := flagSet.Bool("sudo", false, "Use sudo while invoking tar")
-	log.Infof("Exporting container")
-
 	if err := flagSet.Parse(args); err != nil {
 		log.Errorln(err)
 		return -1

--- a/commands/build.go
+++ b/commands/build.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"flag"
+	"fmt"
 	"github.com/PagerDuty/nut/specification"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -41,6 +42,7 @@ func (command *BuildCommand) Synopsis() string {
 func (command *BuildCommand) Run(args []string) int {
 
 	flagSet := flag.NewFlagSet("build", flag.ExitOnError)
+	flagSet.Usage = func() { fmt.Println(command.Help()) }
 
 	file := flagSet.String("specfile", "Dockerfile", "Container build specification file")
 	stopAfterBuild := flagSet.Bool("stop", false, "Stop container after build")

--- a/commands/build.go
+++ b/commands/build.go
@@ -97,7 +97,7 @@ func (command *BuildCommand) Run(args []string) int {
 
 	if *export != "" {
 		log.Infof("Exporting container")
-		if err := spec.ExportContainer(*export, *exportSudo); err != nil {
+		if err := spec.Export(*export, *exportSudo); err != nil {
 			log.Errorf("Failed to export container. Error: %s\n", err)
 			return -1
 		}

--- a/commands/build.go
+++ b/commands/build.go
@@ -4,12 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"github.com/PagerDuty/nut/specification"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"os"
 	"strings"
 )
 
@@ -116,23 +112,8 @@ func (command *BuildCommand) Run(args []string) int {
 		parts := strings.Split(*publish, "/")
 		bucket := parts[0]
 		key := strings.Join(parts[1:], "/")
-		svc := s3.New(session.New(), aws.NewConfig().WithRegion("us-west-1"))
-		fi, err := os.Open(*export)
-		if err != nil {
-			log.Error(err)
-			return -1
-		}
-		defer fi.Close()
-		params := &s3.PutObjectInput{
-			Bucket: aws.String(bucket),
-			Key:    aws.String(key),
-			Body:   fi,
-		}
-
-		log.Infof("Publishing container in s3")
-		_, uploadErr := svc.PutObject(params)
-		if uploadErr != nil {
-			log.Error(uploadErr)
+		if err := specification.Publish(*export, "us-west-1", bucket, key); err != nil {
+			log.Errorln(err)
 			return -1
 		}
 	}

--- a/commands/publish.go
+++ b/commands/publish.go
@@ -1,7 +1,12 @@
 package commands
 
 import (
+	"errors"
+	"flag"
+	"fmt"
+	"github.com/PagerDuty/nut/specification"
 	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 	"strings"
 )
 
@@ -14,14 +19,36 @@ func Publish() (cli.Command, error) {
 
 func (command *PublishCommand) Help() string {
 	helpText := `
+	Usage: nut publish <rootfs.tgz> <region> <bucket> <key>
+
+	nut publish is used to publish a rootfs image into s3
+	Use environment variables or .credential file to pass
+	aws credentials
 	`
 	return strings.TrimSpace(helpText)
 }
 
 func (command *PublishCommand) Synopsis() string {
-	return "Create tarball images of existing container"
+	return "Publish tarball images of existing container in s3"
 }
 
 func (command *PublishCommand) Run(args []string) int {
+
+	flagSet := flag.NewFlagSet("publish", flag.ExitOnError)
+	flagSet.Usage = func() { fmt.Println(command.Help()) }
+	if err := flagSet.Parse(args); err != nil {
+		log.Errorln(err)
+		return -1
+	}
+
+	args = flagSet.Args()
+	if len(args) != 4 {
+		log.Errorln(errors.New("Insufficient argument. Please pass container image file, s3 region, bucket and key"))
+		return -1
+	}
+	if err := specification.Publish(args[0], args[1], args[2], args[3]); err != nil {
+		log.Errorln(err)
+		return -1
+	}
 	return 0
 }

--- a/commands/publish.go
+++ b/commands/publish.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"github.com/mitchellh/cli"
+	"strings"
+)
+
+type PublishCommand struct{}
+
+func Publish() (cli.Command, error) {
+	command := &PublishCommand{}
+	return command, nil
+}
+
+func (command *PublishCommand) Help() string {
+	helpText := `
+	`
+	return strings.TrimSpace(helpText)
+}
+
+func (command *PublishCommand) Synopsis() string {
+	return "Create tarball images of existing container"
+}
+
+func (command *PublishCommand) Run(args []string) int {
+	return 0
+}

--- a/commands/restore.go
+++ b/commands/restore.go
@@ -1,0 +1,60 @@
+package commands
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"github.com/PagerDuty/nut/specification"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
+	"strings"
+)
+
+type RestoreCommand struct{}
+
+func Restore() (cli.Command, error) {
+	command := &RestoreCommand{}
+	return command, nil
+}
+
+func (command *RestoreCommand) Help() string {
+	helpText := `
+	Usage: nut restore [options] <container> <image>
+
+	nut restore is used to create container from archived images
+
+	-sudo    Use sudo while invoking tar
+	`
+	return strings.TrimSpace(helpText)
+}
+
+func (command *RestoreCommand) Synopsis() string {
+	return "Create container from tarball image"
+}
+
+func (command *RestoreCommand) Run(args []string) int {
+	flagSet := flag.NewFlagSet("restore", flag.ExitOnError)
+	flagSet.Usage = func() { fmt.Println(command.Help()) }
+	sudo := flagSet.Bool("sudo", false, "Use sudo while invoking tar")
+	if err := flagSet.Parse(args); err != nil {
+		log.Errorln(err)
+		return -1
+	}
+
+	args = flagSet.Args()
+	if len(args) != 2 {
+		log.Errorln(errors.New("Insufficient argument. Please pass container name and image file name"))
+		return -1
+	}
+
+	if err := specification.DecompressImage(args[0], args[1], *sudo); err != nil {
+		log.Errorf("Failed to restore container. Error: %s\n", err)
+		return -1
+	}
+
+	if err := specification.UpdateUTS(args[0]); err != nil {
+		log.Errorf("Failed to restore container. Error: %s\n", err)
+		return -1
+	}
+	return 0
+}

--- a/commands/run.go
+++ b/commands/run.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"github.com/mitchellh/cli"
+	"strings"
+)
+
+type RunCommand struct{}
+
+func Run() (cli.Command, error) {
+	command := &RunCommand{}
+	return command, nil
+}
+
+func (command *RunCommand) Help() string {
+	helpText := `
+	`
+	return strings.TrimSpace(helpText)
+}
+
+func (command *RunCommand) Synopsis() string {
+	return "Create tarball images of existing container"
+}
+
+func (command *RunCommand) Run(args []string) int {
+	return 0
+}

--- a/nut.go
+++ b/nut.go
@@ -15,8 +15,11 @@ func main() {
 	c := cli.NewCLI("nut", version)
 	c.Args = os.Args[1:]
 	c.Commands = map[string]cli.CommandFactory{
-		"build": commands.Build,
-		"fetch": commands.Fetch,
+		"archive": commands.Archive,
+		"build":   commands.Build,
+		"fetch":   commands.Fetch,
+		"publish": commands.Publish,
+		"run":     commands.Run,
 	}
 	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
 	exitStatus, err := c.Run()

--- a/nut.go
+++ b/nut.go
@@ -19,6 +19,7 @@ func main() {
 		"build":   commands.Build,
 		"fetch":   commands.Fetch,
 		"publish": commands.Publish,
+		"restore": commands.Restore,
 		"run":     commands.Run,
 	}
 	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})

--- a/specification/container.go
+++ b/specification/container.go
@@ -7,6 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/lxc/go-lxc.v2"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -119,4 +120,24 @@ func CloneAndStartContainer(original, cloned, volume string) (*lxc.Container, er
 		return nil, err
 	}
 	return ct, nil
+}
+
+func ExportContainer(name, file string, sudo bool) error {
+	//command := "sudo tar -Jcpf rootfs1.tar.xz -C ~/.local/share/lxc/ruby_2.3/rootfs  . --numeric-owner"
+	lxcdir := lxc.GlobalConfigItem("lxc.lxcpath")
+	ctDir := filepath.Join(lxcdir, name)
+	command := fmt.Sprintf("tar -Jcpf %s --numeric-owner -C %s .", file, ctDir)
+	if sudo {
+		command = "sudo " + command
+	}
+	log.Infof("Invoking: %s", command)
+	parts := strings.Fields(command)
+	cmd := exec.Command(parts[0], parts[1:]...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Error(string(out))
+		log.Error(err)
+		return err
+	}
+	return nil
 }

--- a/specification/container.go
+++ b/specification/container.go
@@ -174,9 +174,6 @@ func UpdateUTS(name string) error {
 	if err != nil {
 		return err
 	}
-	if err := ct.LoadConfigFile(ct.ConfigFileName()); err != nil {
-		return err
-	}
 	if err := ct.SetConfigItem("lxc.utsname", name); err != nil {
 		return err
 	}

--- a/specification/spec.go
+++ b/specification/spec.go
@@ -310,22 +310,6 @@ func (spec *Spec) runCommand(command []string) error {
 	return nil
 }
 
-func (spec *Spec) ExportContainer(file string, sudo bool) error {
-	//command := "sudo tar -Jcpf rootfs1.tar.xz -C ~/.local/share/lxc/ruby_2.3/rootfs  . --numeric-owner"
-	lxcdir := lxc.GlobalConfigItem("lxc.lxcpath")
-	ctDir := filepath.Join(lxcdir, spec.State.Container.Name())
-	command := fmt.Sprintf("tar -Jcpf %s --numeric-owner -C %s .", file, ctDir)
-	if sudo {
-		command = "sudo " + command
-	}
-	log.Infof("Invoking: %s", command)
-	parts := strings.Fields(command)
-	cmd := exec.Command(parts[0], parts[1:]...)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Error(string(out))
-		log.Error(err)
-		return err
-	}
-	return nil
+func (spec *Spec) Export(file string, sudo bool) error {
+	return ExportContainer(spec.State.Container.Name(), file, sudo)
 }


### PR DESCRIPTION
Create an archive from existing container 
```
nut archive -sudo trusty 14.04_image.tzx
```
will create the 14.04_image.tzx file which is archived from the container named trusty

Restore a container from an archived file
```
nut restore -sudo ruby_2.2 /path/to/ruby_2.2.txz 
```
will create a container named ruby_2.2 from the archived imaged file ruby_2.2.txz

Publish is a s3 upload CLI
```
nut publish ruby_2.2.txz us-west1 fresh-containers ruby_2.2
```
will upload the image file in fresh-containers bucket as ruby_2.2 key
