### PR TITLE
[chore] remove publish/archiving from build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,34 +5,31 @@ Build [LXC](http://linuxcontainers.org/) containers using [Dockerfile](https://d
 ### Introduction
 
 Nut is a minimal golang based CLI for building LXC containers. It allows user create containers
-using [Dockerfile](https://docs.docker.com/engine/reference/builder/) like syntax and publishing them in s3. Nut is intended to be used in CI/CD
-infrastructure to build container images as artifacts.
+using [Dockerfile](https://docs.docker.com/engine/reference/builder/) like syntax, archiving and publishing them in s3.
+Nut is intended to be used in CI/CD infrastructure to build & publish container images as artifacts.
 
 ### Usage
+All features of nut are implemented in set of sub commands
+```
+nut --help
+```
 
 ```
-nut build -help
-```
+usage: nut [--version] [--help] <command> [<args>]
+
+Available commands are:
+    archive    Create tarball images of existing container
+    build      Build container from Dockerfile
+    fetch      Create container from images stored in s3
+    multi      Build multi container environment from docker compose specification
+    publish    Publish tarball images of existing container in s3
+    restore    Create container from tarball image
+    run        Run command/entrypoint inside a container
 
 ```
-Usage of build:
-  -ephemeral
-      Destroy the container after creating it
-  -export string
-      File path for the container tarball
-  -export-sudo
-      Use sudo while invoking tar
-  -name string
-      Name of the resulting container (defaults to randomly generated UUID)
-  -publish string
-      Publish tarball in s3 (assumes -stop, -export)
-  -specfile string
-      Container build specification file (default "Dockerfile")
-  -stop
-      Stop container after build
-  -volume string
-      Mount host directory inside container. Format: '[host_directory:]container_directory[:mount options]
-```
+- *build*, *restore* and *fetch* is used create containers from dockerfile like syntax of images stored in s3 or localdisk 
+- *multi* is used to setup multi-container environments from [docker-compose](https://docs.docker.com/compose/compose-file/) like specification.
+- *archive* and *publish*  allows creating and publishing container images in s3
 
 #### Artifact  Labels
 
@@ -74,18 +71,6 @@ Nut converts the image name from  `org/repo:version` to 'org-repo_version' as th
 from which the new container will be built.
 For example `FROM pagerduty/ruby:2.2.3` will instruct Nut to create a container by cloning
 an existing container named `pagerduty-ruby_2.2.3`.
-
-
-### Differences of LXC vs Docker runtime
-
-Since Nut uses LXC it provides system container, which has few key differences from Docker/Rocket style app containers. These include:
-- Container images/tarballs are independent artifacts, they do not have image or unionfs layer dependencies, and can be run without their parent images.
-- Nut does not rely on overlayfs or any other union file system (whatever lxc supports)
-- Nut is built and tested as unprivileged user. Hence `nut` can be run as any normal user (e.g. service X can create and run containers as X).
-- LXC being a system conatiner runtime, does not force you to provide any specific entrypoint. You can model your app as standard linux service instead (init.d script, systmed unit file etc.
-as you would do on host OS  (like using sys-v init script, or upstrat or systemd unit file etc). This also means you dont have to run an explicit process supervisor (like supervisord)
-- Nut runs cron and a handful of additional services (exact list of services depends on the container distro), which means log rotation and all other periodic tasks for long lived containers do not involve anything special.
-
 
 ### Development
 

--- a/commands/build.go
+++ b/commands/build.go
@@ -22,10 +22,7 @@ func (command *BuildCommand) Help() string {
 		-specfile    Local path to the specification file (defaults to dockerfle)
 		-ephemeral   Destroy the container after creation
 		-name        Name of the container (defaults to randomly generated UUID)
-		-stop        Stop container at the end
 		-volume      Mount host directory inside container
-		-export      Create tarball of container rootfs (assumes -stop)
-		-publish     Publish tarball in S3
 	`
 	return strings.TrimSpace(helpText)
 }
@@ -41,29 +38,11 @@ func (command *BuildCommand) Run(args []string) int {
 	flagSet.Usage = func() { fmt.Println(command.Help()) }
 
 	file := flagSet.String("specfile", "Dockerfile", "Container build specification file")
-	stopAfterBuild := flagSet.Bool("stop", false, "Stop container after build")
 	ephemeral := flagSet.Bool("ephemeral", false, "Destroy the container after creating it")
 	name := flagSet.String("name", "", "Name of the resulting container (defaults to randomly generated UUID)")
-	export := flagSet.String("export", "", "File path for the container tarball")
-	exportSudo := flagSet.Bool("export-sudo", false, "Use sudo while invoking tar")
 	volume := flagSet.String("volume", "", "Mount host directory inside container. Format: '[host_directory:]container_directory[:mount options]")
-	publish := flagSet.String("publish", "", "Publish tarball in s3 (assumes -stop, -export)")
 
 	flagSet.Parse(args)
-	if *publish != "" {
-		if *export == "" {
-			uuid, err := specification.UUID()
-			if err != nil {
-				log.Errorln(err)
-				return -1
-			}
-			*export = uuid
-		}
-	}
-
-	if *export != "" {
-		*stopAfterBuild = true
-	}
 	if *name == "" {
 		uuid, err := specification.UUID()
 		if err != nil {
@@ -85,35 +64,10 @@ func (command *BuildCommand) Run(args []string) int {
 		return -1
 	}
 
-	if *stopAfterBuild {
-		log.Infof("Stopping container")
-		if err := spec.Stop(); err != nil {
-			log.Errorf("Failed to stop container. Error: %s\n", err)
-			return -1
-		}
-	}
-
-	if *export != "" {
-		log.Infof("Exporting container")
-		if err := spec.Export(*export, *exportSudo); err != nil {
-			log.Errorf("Failed to export container. Error: %s\n", err)
-			return -1
-		}
-	}
-
 	if *ephemeral {
 		log.Infof("Ephemeral mode. Destroying the container")
 		if err := spec.Destroy(); err != nil {
 			log.Errorf("Failed to destroy container. Error: %s\n", err)
-			return -1
-		}
-	}
-	if *publish != "" {
-		parts := strings.Split(*publish, "/")
-		bucket := parts[0]
-		key := strings.Join(parts[1:], "/")
-		if err := specification.Publish(*export, "us-west-1", bucket, key); err != nil {
-			log.Errorln(err)
 			return -1
 		}
 	}


### PR DESCRIPTION
Archiving, publishing etc are now available from separate commands. Removing those from build command. README update accordingly.